### PR TITLE
ollama can do structure output so there is no need to tell the AI a specific format and needing to retry if the format fails

### DIFF
--- a/prompt.md
+++ b/prompt.md
@@ -22,22 +22,18 @@ Things that ARE allowed:
 - Anime/gaming discussions with sexual themes (as long as no minors)
 - Joking about being horny or sexual topics between adults
 
-Response format: `{"block":true}` or `{"block":false}`
-
-Do not add any additional explanation/justification for your answers,
-only the explicitly allowed responses.
-
 Examples:
 Input: "Buy my product now! 50% off!"
 Output: {"block": true}
+Explanation: This is an advertisement.
 
 Input: "Discount code SAVE20 for 20% off everything!"
 Output: {"block": true}
+Explanation: This is an advertisement.
 
 Input: "Hello everyone, how are you today?"
 Output: {"block": false}
+Explanation: This is just asking how people are.
 
 Analyze this post:
 CONTENTPLACEHOLDER:p
-
-Response:


### PR DESCRIPTION
That's the only change I made. Here is the ollama documentation explaining structured output: https://ollama.com/blog/structured-outputs. It just can force the AI to **always** respond in a specific structure instead of having to inject it into the prompt. Additionally, I made it, so the file is only being read once at start instead of each attempt at filtering, since it would be assumed it's non-changing, and it reduces read/disk latency for each filter attempt.